### PR TITLE
Improvements based on phpstan feedback downstream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
         "phpunit/phpunit": "^11.5",
         "rector/rector": "^1.2"
     },
+    "autoload-dev": {
+        "psr-4": {
+            "PicqerExactPhpClientGeneratorTest\\": "tests/"
+        }
+    },
     "config": {
         "sort-packages": true
     }

--- a/src/Command/ModelGenerateCommand.php
+++ b/src/Command/ModelGenerateCommand.php
@@ -60,7 +60,7 @@ HELP
 
         $endpoints = $metaData->endpoints;
         if ($input->getOption('endpoint')) {
-            $endpoints = $endpoints->filter(fn(Endpoint $endpoint) => $endpoint->name === $input->getOption('endpoint'));
+            $endpoints = $endpoints->filter(fn(Endpoint $endpoint) => $endpoint->uri === $input->getOption('endpoint'));
         }
 
         $templating = $this->createTemplateEngine();

--- a/src/Decorator/EndpointDecorator.php
+++ b/src/Decorator/EndpointDecorator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PicqerExactPhpClientGenerator\Decorator;
 
+use PicqerExactPhpClientGenerator\NamingHelper;
 use PicqerExactPhpClientGenerator\ValueObject\Endpoint;
 use PicqerExactPhpClientGenerator\ValueObject\Property;
 use PicqerExactPhpClientGenerator\ValueObject\PropertyCollection;
@@ -25,7 +26,11 @@ class EndpointDecorator
 
     public function getFilename(): string
     {
-        return sprintf('%s/src/Picqer/Financials/Exact/%s.php', $this->path, $this->getClassName());
+        return sprintf(
+            '%s/src/Picqer/Financials/Exact/%s.php',
+            $this->path,
+            NamingHelper::getClassName($this->endpoint)
+        );
     }
 
     public function getNonObsoleteProperties(): PropertyCollection
@@ -33,76 +38,6 @@ class EndpointDecorator
         return $this->endpoint->properties->filter(
             fn(Property $p):bool => !$p->isHidden && !str_contains(strtolower($p->description), 'obsolete')
         );
-    }
-
-    public function getClassName(): string
-    {
-        $isSyncEndpoint = str_contains($this->endpoint->uri, '/api/v1/{division}/sync');
-
-        // Some cases don't follow the naming conventions, have naming clashes within Exact or are reserved keywords in PHP
-        $namingConventionExceptions = [
-            '/api/v1/system/Users' => 'SystemUser',
-            '/api/v1/{division}/system/Divisions' => 'SystemDivision',
-            '/api/v1/{division}/hrm/Divisions' => 'HrmDivision',
-            '/api/v1/{division}/vat/VATCodes' => 'VatCode',
-            '/api/v1/{division}/read/financial/Returns' => 'Returns', // Return is a reserved keyword in PHP
-            '/api/v1/{division}/openingbalance/PreviousYear/AfterEntry' =>'PreviousYearAfterEntry',
-            '/api/v1/{division}/sync/Cashflow/PaymentTerms' => 'SyncPaymentTerm',
-            '/api/v1/{division}/openingbalance/PreviousYear/Processed' => 'PreviousYearProcessed',
-            '/api/v1/{division}/read/project/RecentCostsByNumberOfWeeks' => 'RecentCostsByNumberOfWeeks',
-            '/api/v1/{division}/read/project/RecentHoursByNumberOfWeeks' => 'RecentHoursByNumberOfWeeks',
-            '/api/v1/{division}/read/crm/Documents' => 'CrmDocument',
-            '/api/v1/{division}/read/crm/DocumentsAttachments' => 'CrmDocumentAttachment',
-            '/api/v1/{division}/read/financial/RevenueListByYearAndStatus?year={Edm.Int32}&afterEntry={Edm.Boolean}' => 'RevenueListByYearAndStatus',
-            '/api/v1/{division}/logistics/ReasonCodes' => 'LogisticsReasonsCodes', // As it collides with '/api/v1/{division}/crm/ReasonCodes'
-            '/api/v1/{division}/openingbalance/CurrentYear/AfterEntry' => 'CurrentYearAfterEntry',
-            '/api/v1/{division}/openingbalance/CurrentYear/Processed' => 'CurrentYearProcessed',
-            '/api/v1/{division}/sync/Inventory/ItemWarehouses' => 'SyncInventoryItemWarehouse',
-            '/api/v1/{division}/manufacturing/TimeTransactions' => 'ManufacturingTimeTransaction',
-            '/api/v1/{division}/project/TimeTransactions' => 'ProjectTimeTransaction',
-
-        ];
-
-        if (array_key_exists($this->endpoint->uri, $namingConventionExceptions)) {
-            return $namingConventionExceptions[$this->endpoint->uri];
-        }
-
-        // Some cases aren't properly handled by inflector
-        $exceptions = [
-            'EmploymentContractFlexPhases' => 'EmploymentContractFlexPhase',
-            'ItemWarehouses' => 'ItemWarehouse',
-            'Inventory/ItemWarehouses' => 'InventoryItemWarehouse',
-            'Warehouses' => 'Warehouse',
-            'BulkProjectProjectWBS' => 'BulkProjectProjectWBS',
-            'ReadProjectProjectWBSByProjectAndWBS' => 'ReadProjectProjectWBSByProjectAndWBS',
-            'SalesItemPrice' => 'SalesItemPrice',
-            'TimeAndBillingActivitiesAndExpenses' => 'TimeAndBillingActivitiesAndExpense',
-            'TimeAndBillingEntryRecentActivitiesAndExpenses' => 'TimeAndBillingEntryRecentActivitiesAndExpense',
-            'WBSExpenses' => 'WBSExpense',
-            'Project/ProjectWBS' => 'ProjectWBS',
-            'ProjectWBSByProjectAndWBS' => 'ProjectWBSByProjectAndWBS',
-            'RevenueListByYearAndStatus' => 'RevenueListByYearAndStatus',
-            'LeadPurposes' => 'LeadPurpose',
-        ];
-
-        if (array_key_exists($this->endpoint->name, $exceptions)) {
-            if ($isSyncEndpoint) {
-                return 'Sync' . $exceptions[$this->endpoint->name];
-            }
-            return $exceptions[$this->endpoint->name];
-        }
-
-        $inflector = $this->getInflector();
-        $parts = explode('/', $this->endpoint->name);
-        $className = array_pop($parts);
-        $singleOptions = $inflector->singularize($className);
-        $name = array_pop($singleOptions);
-
-        if ($isSyncEndpoint) {
-            return 'Sync' . $name;
-        }
-
-        return $name;
     }
 
     public function getClassUri(): string

--- a/src/EndpointClassFacade.php
+++ b/src/EndpointClassFacade.php
@@ -42,7 +42,7 @@ readonly class EndpointClassFacade
             'isDeprecated' => $this->endpoint->isDeprecated,
             'filename' => $this->endpointDecorator->getFileName(),
             'strictTypes' => $this->codeExtract->getStrictType(),
-            'className' => $this->endpointDecorator->getClassName(),
+            'className' => NamingHelper::getClassName($this->endpoint),
             'documentation' => $this->endpoint->documentation,
             'deprecationDocComment' => $this->codeExtract->getDeprecationDocComment(),
             'additionalClassDocComment' => $this->codeExtract->getAdditionalClassDocComment(),

--- a/src/NamingHelper.php
+++ b/src/NamingHelper.php
@@ -142,6 +142,52 @@ class NamingHelper
                 '/api/v1/{division}/bulk/SalesOrder/GoodsDeliveryLines' => match ($property->type) {
                     'StockBatchNumbers' => 'StockBatchNumber[]',
                     'StockSerialNumbers' => 'StockSerialNumber[]',
+                },
+                '/api/v1/{division}/salesorder/DigitalOrderPickingLines' => match ($property->type) {
+                    'PickingLocations' => 'DigitalOrderPickingLine[]',
+                },
+                '/api/v1/{division}/hrm/Divisions' => match ($property->type) {
+                    'DivisionClasses' => 'DivisionClass',
+                },
+                '/api/v1/{division}/logistics/ItemAssortment' => match ($property->type) {
+                    'Properties' => 'ItemAssortmentProperty[]',
+                },
+                '/api/v1/{division}/logistics/ReasonCodes' => match ($property->type) {
+                    'Types' => 'ReasonCodesLinkType[]'
+                },
+                '/api/v1/{division}/read/financial/PayablesList',
+                '/api/v1/{division}/read/financial/PayablesListByAccount',
+                '/api/v1/{division}/read/financial/PayablesListByAccountAndAgeGroup',
+                '/api/v1/{division}/read/financial/PayablesListByAgeGroup',
+                '/api/v1/{division}/read/financial/ReceivablesList',
+                '/api/v1/{division}/read/financial/ReceivablesListByAccount',
+                '/api/v1/{division}/read/financial/ReceivablesListByAccountAndAgeGroup',
+                '/api/v1/{division}/read/financial/ReceivablesListByAgeGroup' => match ($property->type) {
+                    'Notes' => 'string[]',
+                },
+                '/api/v1/{division}/cashflow/ProcessPayments' => match ($property->type) {
+                    'PaymentIDs' => '\stdClass[]',
+                },
+                '/api/v1/{division}/project/Projects' => match ($property->type) {
+                    'BudgetedHoursPerHourType' => 'ProjectHourBudget',
+                },
+                '/api/v1/{division}/logistics/ReasonForLogistics' => match ($property->type) {
+                    'Types' => 'ReasonForLogisticsLinkType[]',
+                },
+                '/api/v1/{division}/hrm/Schedules' => match ($property->type) {
+                    'ScheduleEntries' => 'mixed[]'
+                },
+                '/api/v1/{division}/manufacturing/ShopOrders' => match ($property->type) {
+                    'SalesOrderlines' => 'SalesOrderLine[]'
+                },
+                '/api/v1/{division}/manufacturing/ShopOrderRoutingStepPlans' => match ($property->type) {
+                    'TimeTransactions' => 'ManufacturingTimeTransaction[]',
+                },
+                'users/Users' => match ($property->type) {
+                    'UserRoles' => 'UserRole[]',
+                },
+                '/api/v1/{division}/vat/VATCodes' => match ($property->type) {
+                    'VATPercentages' => 'VatPercentage[]'
                 }
             };
         } catch (\UnhandledMatchError) {

--- a/tests/Unit/NamingHelperTest.php
+++ b/tests/Unit/NamingHelperTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PicqerExactPhpClientGeneratorTest\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use PicqerExactPhpClientGenerator\NamingHelper;
+use PicqerExactPhpClientGenerator\ValueObject\Endpoint;
+use PicqerExactPhpClientGenerator\ValueObject\PropertyCollection;
+use PicqerExactPhpClientGenerator\ValueObject\SupportedMethods;
+
+#[CoversClass(NamingHelper::class)]
+class NamingHelperTest extends TestCase
+{
+    #[DataProvider('ExpectedClassNameDataProvider')]
+    public function testGeneratesCorrectClassName(
+        string $name,
+        string $uri,
+        string $expectedClassName,
+    ): void
+    {
+        $endpoint = new Endpoint(
+            name: $name,
+            documentation: '',
+            scope: '',
+            uri: $uri,
+            supportedMethods: new SupportedMethods(get: true, post: true, put: true, delete: true),
+            example: '',
+            properties: new PropertyCollection(),
+            isDeprecated: false
+        );
+
+        $result = NamingHelper::getClassName($endpoint);
+
+        self::assertEquals($expectedClassName, $result);
+    }
+
+    public static function ExpectedClassNameDataProvider(): \Generator
+    {
+        // Exceptions
+        yield 'SystemUser' => [
+            'name' => 'Users',
+            'uri' => '/api/v1/system/Users',
+            'expectedClassName' => 'SystemUser'
+        ];
+
+        // Bulk
+        yield 'BulkGoodsDelivery' => [
+            'name' => 'SalesOrder/GoodsDeliveries',
+            'uri' => '/api/v1/{division}/bulk/SalesOrder/GoodsDeliveries',
+            'expectedClassName' => 'BulkGoodsDelivery'
+        ];
+        yield 'BulkGoodsDeliveryLine' => [
+            'name' => 'SalesOrder/GoodsDeliveryLines',
+            'uri' => '/api/v1/{division}/bulk/SalesOrder/GoodsDeliveryLines',
+            'expectedClassName' => 'BulkGoodsDeliveryLine'
+        ];
+    }
+
+}


### PR DESCRIPTION
After running PHPStan on the [picqer/exact-php-client](https://github.com/picqer/exact-php-client/issues) project several issues were found which originate in this library as direct result of typos in the documentation. This PR addresses these issues in a new approach to make these "exceptions" more explicit and dont try to apply generic logic which won't cover everything but only the majority.